### PR TITLE
Switching NTC 100K beta 3950 to Generic 3950

### DIFF
--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -62,7 +62,7 @@ max_temp: 120
 #   Chamber
 #####################################################################
 [temperature_sensor chamber]
-sensor_type: NTC 100K beta 3950
+sensor_type: Generic 3950
 sensor_pin: PF4
 min_temp: 0
 max_temp: 100


### PR DESCRIPTION
Updated per the [Klipper Documentation](https://docs.mainsail.xyz/faq/klipper_warnings/deprecated_value) to resolve the removal of `NTC 100L beta 3950` temperature sensors.